### PR TITLE
Update base docker to ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Intall system utilities
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update && \
+    apt-get install -y --no-install-recommends tzdata &&\
     apt-get install -y \
     wget \
     curl \


### PR DESCRIPTION
This PR updates the base docker image from Ubuntu 18.04 to Ubuntu 20.04.

Maintenance like this is required in order to keep smurf software and OCS / Simons Observatory software compatible, as OCS requires a newer version of python (>=3.7) to run.

I've had success building this, the `pysmurf-client` and `smurf-rogue` dockers, but have not tested in a real system. I'm not exactly sure the best way to test this, as it requires the full container stack to be rebuilt, some of which like the pysmurf-server requires private fw files that I don't think I have access to. @slacrherbst or @swh76, how should we go about pushing this through?