### PR TITLE
Upgrade Ubuntu from 18.04 to 20.04.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 # Intall system utilities
 RUN DEBIAN_FRONTEND=noninteractive \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 # Intall system utilities
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update && \
+    apt-get install -y --no-install-recommends tzdata &&\
     apt-get install -y \
     wget \
     curl \
@@ -62,8 +63,8 @@ RUN git clone https://github.com/slaclab/smurftestapps.git
 # Create the user cryo and the group smurf. Add the cryo user
 # to the smurf group, as primary group. And create its home
 # directory with the right permissions
-RUN useradd -d /home/cryo -M cryo && \
-    groupadd smurf && \
+RUN useradd -d /home/cryo -M cryo -u 1000 && \
+    groupadd smurf -g 1001 && \
     usermod -aG smurf cryo && \
     usermod -g smurf cryo && \
     mkdir /home/cryo && \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This docker image, named **smurf-base** contains all the base tools used by the SMuRF project.
 
-It is based on ubuntu 18.04, and contains:
+It is based on ubuntu 22.04, and contains:
 - Basic system tools
 - python3
 - Python3 modules
@@ -39,3 +39,17 @@ docker run -ti --rm --name smurf-base tidair/smurf-base:TAG
 ```
 
 TAG represents the specific tagged version you want to use. You will be given a bash shell where you can run the any of the tools provided by this docker image. You can also add commands at the  of the docker run command, in this case the container will be started, the command will be run, and the container will be stopped. Note that the container must be run in a server with access to the ATCA system you plan to use. This image should be able to reach both the pysmurf server IOC as well as the timing pattern generator (TPG) IOC.
+
+## Building the image locally
+
+To test without releasing, can build locally by running
+
+```
+docker build . -t smurf-base
+```
+
+on the command line in the top smurf-base-docker repository directory.  If successful, can enter a bash session in the new image via
+
+```
+docker run -ti --rm --name smurf-base smurf-base:latest
+```


### PR DESCRIPTION
Needed because GitHub is no longer supporting Ubuntu 18.04  (https://github.com/slaclab/pysmurf/issues/764), so we must upgrade to 20.04 (the next LTS version) in order to be able to build new SMuRF software releases.  
Some small changes needed in the `Dockerfile`, mostly copied from https://github.com/simonsobs/smurf_dockers/blob/main/smurf_base/Dockerfile.  Was able to build locally and enter docker on a SMuRF server.  
Jack Lashner says these lines
https://github.com/slaclab/smurf-base-docker/blob/26a2aed76ca177ccca4966ccf80d2e0d3b42fc60/Dockerfile#L66-L67
are useful to set same group / user ids in the docker as we use by default on the SMuRF servers.
I plan to release as R2.0.0.