### PR TITLE
Upgrade from Ubuntu 20.04 to Ubuntu 22.04.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Intall system utilities
 RUN DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Ubuntu 20.04 is being retired.  Must upgrade to Ubuntu 22.04.